### PR TITLE
Improve Linux filesystem support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/CSharpExt.UnitTests/CSharpExt.UnitTests.csproj
+++ b/CSharpExt.UnitTests/CSharpExt.UnitTests.csproj
@@ -31,12 +31,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Noggog.Autofac\Noggog.Autofac.csproj" />
     <ProjectReference Include="..\Noggog.CSharpExt.Json\Noggog.CSharpExt.Json.csproj" />
-    <ProjectReference Include="..\Noggog.CSharpExt.Windows\Noggog.CSharpExt.Windows.csproj" />
+    <ProjectReference Include="..\Noggog.CSharpExt.Windows\Noggog.CSharpExt.Windows.csproj" Condition="!$([MSBuild]::IsOSUnixLike())" />
     <ProjectReference Include="..\Noggog.CSharpExt\Noggog.CSharpExt.csproj" />
     <ProjectReference Include="..\Noggog.Testing\Noggog.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="IO\SingleApplicationEnforcerTests.cs" Condition="$([MSBuild]::IsOSUnixLike())"  />
     <None Update="IO\Files\OldDirectoryPathSerialization.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CSharpExt.UnitTests/TempFileFolder_Tests.cs
+++ b/CSharpExt.UnitTests/TempFileFolder_Tests.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using FluentAssertions;
+using Noggog.Utility;
+using Xunit;
+namespace CSharpExt.UnitTests
+{
+    public class TempFileFolderTests
+    {
+        [Fact]
+        public void TempFolder_Exists()
+        {
+            var filepath = Path.Combine(Path.GetTempPath(), $"CSharpEXT/Test");
+            using (var tmp = TempFolder.FactoryByPath(filepath, deleteAfter: true))
+            {
+                Directory.Exists(filepath).Should().BeTrue();
+            }
+            Directory.Exists(filepath).Should().BeFalse();
+        }
+
+        [Fact]
+        public void TempFile_DeleteAfter()
+        {
+            string path;
+            using (var tmp = new TempFile(deleteAfter: true))
+            {
+                path = tmp.File.Path.ToString();
+            }
+            File.Exists(path).Should().BeFalse();
+        }
+    }
+}

--- a/Noggog.Autofac/Noggog.Autofac.csproj
+++ b/Noggog.Autofac/Noggog.Autofac.csproj
@@ -36,7 +36,7 @@
     </ItemGroup>
 
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.autofac&quot;" />
+        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.autofac&quot;" Condition="!$([MSBuild]::IsOSUnixLike())" />
     </Target>
 
 </Project>

--- a/Noggog.CSharpExt.Json/Noggog.CSharpExt.Json.csproj
+++ b/Noggog.CSharpExt.Json/Noggog.CSharpExt.Json.csproj
@@ -48,7 +48,7 @@
     </ItemGroup>
 
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.csharpext.json&quot;" />
+        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.csharpext.json&quot;" Condition="!$([MSBuild]::IsOSUnixLike())" />
     </Target>
 
 </Project>

--- a/Noggog.CSharpExt/Noggog.CSharpExt.csproj
+++ b/Noggog.CSharpExt/Noggog.CSharpExt.csproj
@@ -49,7 +49,7 @@
   </ItemGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.csharpext&quot;" />
+    <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.csharpext&quot;" Condition="!$([MSBuild]::IsOSUnixLike())" />
   </Target>
 
 </Project>

--- a/Noggog.CSharpExt/Structs/FileSystems/DirectoryPath.cs
+++ b/Noggog.CSharpExt/Structs/FileSystems/DirectoryPath.cs
@@ -11,7 +11,7 @@ namespace Noggog
     {
         private readonly string? _fullPath;
         private readonly string? _originalPath;
-        
+
         [IgnoreDataMember]
         public DirectoryPath? Directory
         {
@@ -25,18 +25,18 @@ namespace Noggog
 
         [IgnoreDataMember]
         public bool Exists => CheckExists();
-        
+
         [IgnoreDataMember]
         public string Path => _fullPath ?? string.Empty;
-        
+
         public string RelativePath => _originalPath ?? string.Empty;
-        
+
         [IgnoreDataMember]
         public FileName Name => System.IO.Path.GetFileName(Path);
-        
+
         [IgnoreDataMember]
         public bool Empty => CheckEmpty();
-        
+
         public DirectoryPath(string relativePath)
         {
 #if NETSTANDARD2_0
@@ -44,10 +44,10 @@ namespace Noggog
 #else 
             relativePath = System.IO.Path.TrimEndingDirectorySeparator(relativePath);
 #endif
-            this._originalPath = relativePath.Replace('/', '\\');;
+            this._originalPath = relativePath.Replace('/', System.IO.Path.DirectorySeparatorChar);
             this._fullPath = relativePath == string.Empty ? string.Empty : System.IO.Path.GetFullPath(relativePath);
         }
-        
+
         public bool CheckExists(IFileSystem? fs = null) => fs.GetOrDefault().Directory.Exists(Path);
 
         public static bool operator ==(DirectoryPath lhs, DirectoryPath rhs)
@@ -89,7 +89,7 @@ namespace Noggog
 
         [Obsolete("Use IsUnderneath instead")]
         public bool IsSubfolderOf(DirectoryPath potentialParent) => IsUnderneath(potentialParent);
-        
+
         // ToDo
         // Can maybe be improved to not check full path on each level
         public bool IsUnderneath(DirectoryPath potentialParent)
@@ -159,14 +159,14 @@ namespace Noggog
             return !fileSystem.Directory.EnumerateFiles(Path).Any()
                 && !fileSystem.Directory.EnumerateDirectories(Path).Any();
         }
-        
+
         public string GetRelativePathTo(DirectoryPath relativeTo)
         {
             return PathExt.MakeRelativePath(
                 relativeTo.Path + System.IO.Path.DirectorySeparatorChar,
                 Path);
         }
-        
+
         public string GetRelativePathTo(FilePath relativeTo)
         {
             return PathExt.MakeRelativePath(
@@ -175,7 +175,7 @@ namespace Noggog
         }
 
         public IEnumerable<FilePath> EnumerateFiles(
-            bool recursive = false, 
+            bool recursive = false,
             string? searchPattern = null,
             IFileSystem? fileSystem = null)
         {
@@ -186,7 +186,7 @@ namespace Noggog
         }
 
         public IEnumerable<DirectoryPath> EnumerateDirectories(
-            bool includeSelf, 
+            bool includeSelf,
             bool recursive,
             IFileSystem? fileSystem = null)
         {
@@ -210,9 +210,9 @@ namespace Noggog
         {
             return dir.RelativePath;
         }
-        
-#if NETSTANDARD2_0 
-#else 
+
+#if NETSTANDARD2_0
+#else
         public static implicit operator ReadOnlySpan<char>(DirectoryPath dir)
         {
             return dir.RelativePath;

--- a/Noggog.CSharpExt/Structs/FileSystems/FilePath.cs
+++ b/Noggog.CSharpExt/Structs/FileSystems/FilePath.cs
@@ -21,30 +21,30 @@ namespace Noggog
                 return new DirectoryPath(dirPath);
             }
         }
-        
+
         [IgnoreDataMember]
         public string Path => _fullPath ?? string.Empty;
-        
+
         public string RelativePath => _originalPath ?? string.Empty;
 
-        [IgnoreDataMember] 
+        [IgnoreDataMember]
         public FileName Name => System.IO.Path.GetFileName(Path);
-            
+
         [IgnoreDataMember]
         public string Extension => System.IO.Path.GetExtension(Path);
-        
+
         [IgnoreDataMember]
         public string NameWithoutExtension => System.IO.Path.GetFileNameWithoutExtension(Path);
-        
+
         [IgnoreDataMember]
         public bool Exists => CheckExists();
 
         public FilePath(string relativePath)
         {
-            this._originalPath = relativePath.Replace('/', '\\');
+            this._originalPath = relativePath.Replace('/', System.IO.Path.DirectorySeparatorChar);
             this._fullPath = relativePath == string.Empty ? string.Empty : System.IO.Path.GetFullPath(relativePath);
         }
-        
+
         public bool CheckExists(IFileSystem? fs = null) => fs.GetOrDefault().File.Exists(_fullPath);
 
         public static bool operator ==(FilePath lhs, FilePath rhs)
@@ -71,7 +71,7 @@ namespace Noggog
         public string GetRelativePathTo(DirectoryPath relativeTo)
         {
             return PathExt.MakeRelativePath(
-                relativeTo.Path + "\\",
+                relativeTo.Path + System.IO.Path.DirectorySeparatorChar,
                 Path);
         }
 

--- a/Noggog.Testing/Noggog.Testing.csproj
+++ b/Noggog.Testing/Noggog.Testing.csproj
@@ -33,7 +33,7 @@
     </ItemGroup>
 
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.testing&quot;" />
+        <Exec Command="RD /S /Q &quot;%25USERPROFILE%25\.nuget\packages\noggog.testing&quot;" Condition="!$([MSBuild]::IsOSUnixLike())" />
     </Target>
 
 </Project>


### PR DESCRIPTION
This PR fixes the assumption that \ is always the only directory separator. It also improves some filesystem tests to make them pass on Linux. Some test are only useful on Windows (such as case insensitivity) and have been disabled on Linux. It also stops build commands from running which were causing the projects to fail to load on Linux.
I was initially hesitant to post this PR as both omnisharp and "dotnet format" removes the indenting of blank lines, but indenting like this is apparently not common and not consistently applied in the entire solution anyways.