### PR TITLE
make both Percent and UDouble readonly (thus immutable).

### DIFF
--- a/Noggog.CSharpExt/Structs/Numbers/Percent.cs
+++ b/Noggog.CSharpExt/Structs/Numbers/Percent.cs
@@ -1,6 +1,6 @@
 namespace Noggog;
 
-public struct Percent : IComparable, IEquatable<Percent>
+public readonly struct Percent : IComparable, IEquatable<Percent>, IComparable<Percent>
 {
     public static readonly Percent One = new Percent(1d);
     public static readonly Percent Zero = new Percent(0d);
@@ -59,7 +59,7 @@ public struct Percent : IComparable, IEquatable<Percent>
     {
         if (double.IsNaN(d) || double.IsInfinity(d))
         {
-            throw new ArgumentException();
+            throw new ArgumentException("Argument value out of range", nameof(d));
         }
         if (d < 0)
         {
@@ -173,4 +173,39 @@ public struct Percent : IComparable, IEquatable<Percent>
         p = default(Percent);
         return false;
     }
+
+    public int CompareTo(Percent other) => this.Value.CompareTo(other.Value);
+
+    public static bool operator ==(Percent left, Percent right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(Percent left, Percent right)
+    {
+        return !(left == right);
+    }
+
+    public static bool operator <(Percent left, Percent right)
+    {
+        return left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(Percent left, Percent right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
+
+    public static bool operator >(Percent left, Percent right)
+    {
+        return left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(Percent left, Percent right)
+    {
+        return left.CompareTo(right) >= 0;
+    }
+
+    public static implicit operator Percent(int i) => new Percent(i);
+    public static implicit operator Percent(double d) => new Percent(d);
 }

--- a/Noggog.CSharpExt/Structs/Numbers/Percent.cs
+++ b/Noggog.CSharpExt/Structs/Numbers/Percent.cs
@@ -205,7 +205,4 @@ public readonly struct Percent : IComparable, IEquatable<Percent>, IComparable<P
     {
         return left.CompareTo(right) >= 0;
     }
-
-    public static implicit operator Percent(int i) => new Percent(i);
-    public static implicit operator Percent(double d) => new Percent(d);
 }

--- a/Noggog.CSharpExt/Structs/Numbers/UDouble.cs
+++ b/Noggog.CSharpExt/Structs/Numbers/UDouble.cs
@@ -1,6 +1,6 @@
 namespace Noggog;
 
-public struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UDouble>
+public readonly struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UDouble>
 {
     public readonly double Value;
     public const double MinValue = 0d;
@@ -43,15 +43,20 @@ public struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UD
         return d.Value - amount;
     }
 
+    public static UDouble operator +(UDouble d, double amount)
+    {
+        return d.Value + amount;
+    }
+
     public override bool Equals(object? obj)
     {
         if (obj is UDouble uRhs)
         {
             return Value == uRhs.Value;
         }
-        else if (obj is double)
+        else if (obj is double d)
         {
-            return Value == (double)obj;
+            return Value == d;
         }
         else
         {
@@ -91,8 +96,9 @@ public struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UD
 
     public static UDouble Parse(string str)
     {
-        TryParse(str, out UDouble ud);
-        return ud;
+        if (TryParse(str, out UDouble ud))
+            return ud;
+        return default;
     }
 
     public static bool TryParse(string str, out UDouble doub)
@@ -108,7 +114,7 @@ public struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UD
 
     public bool EqualsWithin(UDouble rhs, double within = 0.000000001d)
     {
-        return rhs.Value.EqualsWithin(rhs.Value, within);
+        return Value.EqualsWithin(rhs.Value, within);
     }
 
     public bool IsInRange(UDouble min, UDouble max)
@@ -130,5 +136,35 @@ public struct UDouble : IComparable<UDouble>, IComparable<double>, IEquatable<UD
         if (Value < min) return min;
         if (Value > max) return max;
         return Value;
+    }
+
+    public static bool operator ==(UDouble left, UDouble right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(UDouble left, UDouble right)
+    {
+        return !(left == right);
+    }
+
+    public static bool operator <(UDouble left, UDouble right)
+    {
+        return left.CompareTo(right) < 0;
+    }
+
+    public static bool operator <=(UDouble left, UDouble right)
+    {
+        return left.CompareTo(right) <= 0;
+    }
+
+    public static bool operator >(UDouble left, UDouble right)
+    {
+        return left.CompareTo(right) > 0;
+    }
+
+    public static bool operator >=(UDouble left, UDouble right)
+    {
+        return left.CompareTo(right) >= 0;
     }
 }


### PR DESCRIPTION
add comparison and equality operators for both.
add implicit conversions to Percent from int and double. fix UDouble.EqualsWithin effectively comparing itself to itself.