### PR TITLE
Build cleanup: reduce warnings, add unit tests, modernize project

### DIFF
--- a/CSharpExt.UnitTests/PercentTests.cs
+++ b/CSharpExt.UnitTests/PercentTests.cs
@@ -147,7 +147,10 @@ public class PercentTests
         c.ShouldBeTrue();
         c = p2 < p1;
         c.ShouldBeFalse();
+
+#pragma warning disable CS1718 // Intentional self-comparison to test operators
         c = p1 < p1;
+#pragma warning restore CS1718
         c.ShouldBeFalse();
     }
 
@@ -160,7 +163,9 @@ public class PercentTests
         c.ShouldBeTrue();
         c = p2 <= p1;
         c.ShouldBeFalse();
+#pragma warning disable CS1718 // Intentional self-comparison to test operators
         c = p1 <= p1;
+#pragma warning restore CS1718
         c.ShouldBeTrue();
     }
 
@@ -173,7 +178,9 @@ public class PercentTests
         c.ShouldBeFalse();
         c = p2 >= p1;
         c.ShouldBeTrue();
+#pragma warning disable CS1718 // Intentional self-comparison to test operators
         c = p1 >= p1;
+#pragma warning restore CS1718
         c.ShouldBeTrue();
     }
 
@@ -186,7 +193,9 @@ public class PercentTests
         c.ShouldBeFalse();
         c = p2 > p1;
         c.ShouldBeTrue();
+#pragma warning disable CS1718 // Intentional self-comparison to test operators
         c = p1 > p1;
+#pragma warning restore CS1718
         c.ShouldBeFalse();
     }
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,7 +66,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.0')) ">
     <PackageVersion Update="System.Buffers" Version="4.5.1" />
     <PackageVersion Update="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Threading.Tasks" Version="4.3.0" />
+
     <PackageVersion Update="Microsoft.Bcl.HashCode" Version="1.1.1" />
   </ItemGroup>
 </Project>

--- a/Noggog.CSharpExt/Noggog.CSharpExt.csproj
+++ b/Noggog.CSharpExt/Noggog.CSharpExt.csproj
@@ -33,10 +33,6 @@
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard2.0')) ">
-    <PackageReference Include="System.Threading.Tasks" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.HashCode" />
     <PackageReference Include="System.Buffers" />

--- a/Noggog.CSharpExt/WorkEngine/WorkConsumer.cs
+++ b/Noggog.CSharpExt/WorkEngine/WorkConsumer.cs
@@ -152,7 +152,7 @@ public class WorkConsumer : IDisposable, IWorkConsumer
             .Select(x => x ?? 0)
             .Select(x => x == 0 ? Environment.ProcessorCount : x)
             .DistinctUntilChanged()
-            .Subscribe(AddNewThreadsIfNeeded)
+            .SubscribeAsyncConcat(AddNewThreadsIfNeeded)
             .DisposeWithComposite(_disposable);
     }
 

--- a/Noggog.Testing/Extensions/ShouldlyExt.cs
+++ b/Noggog.Testing/Extensions/ShouldlyExt.cs
@@ -44,7 +44,7 @@ public static class ShouldlyExt
             TLhs? convertedExpected = (TLhs?)ConvertWithImplicitOperator(expected, actual.GetType());
             if (object.Equals(actual, convertedExpected)) return true;
         }
-        catch (Exception e)
+        catch (Exception)
         {
         }
         
@@ -53,7 +53,7 @@ public static class ShouldlyExt
             TLhs? convertedExpected = (TLhs?)Convert.ChangeType(expected, actual.GetType());
             if (object.Equals(actual, convertedExpected)) return true;
         }
-        catch (Exception e)
+        catch (Exception)
         {
         }
         
@@ -64,7 +64,7 @@ public static class ShouldlyExt
                 var convertedExpected = convertibleExpected.ToType(actual.GetType(), null);
                 if (object.Equals(actual, convertedExpected)) return true;
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/Noggog.Testing/FileSystem/MockFileSystemWatcher.cs
+++ b/Noggog.Testing/FileSystem/MockFileSystemWatcher.cs
@@ -84,7 +84,9 @@ public class MockFileSystemWatcher : IFileSystemWatcher
     public event FileSystemEventHandler? Changed;
     public event FileSystemEventHandler? Created;
     public event FileSystemEventHandler? Deleted;
+#pragma warning disable CS0067 // Required by IFileSystemWatcher interface
     public event ErrorEventHandler? Error;
+#pragma warning restore CS0067
     public event RenamedEventHandler? Renamed;
 
     public MockFileSystemWatcher(IFileSystem fileSystem)

--- a/Noggog.WPF/Extensions/DependencyObjectExt.cs
+++ b/Noggog.WPF/Extensions/DependencyObjectExt.cs
@@ -16,7 +16,7 @@ public static class DependencyObjectExt
             {
                 item = VisualTreeHelper.GetParent(item);
             }
-            catch (InvalidOperationException e)
+            catch (InvalidOperationException)
             {
                 break;
             }


### PR DESCRIPTION
## Summary

A collection of build hygiene improvements that reduce compiler warnings from 126 to 94 and modernize the project infrastructure.

## Changes

### Build warning reduction (126 → 94)
- Removed unnecessary `System.Threading.Tasks` package reference that NuGet flagged as redundant (NU1510)
- Removed unused catch exception variables in `ShouldlyExt.cs` and `DependencyObjectExt.cs` (CS0168)
- Suppressed intentional self-comparison warnings in `PercentTests.cs` operator tests (CS1718)
- Suppressed interface-required but unused `Error` event in `MockFileSystemWatcher` (CS0067)
- Replaced obsolete `Subscribe` call with `SubscribeAsyncConcat` in `WorkConsumer` (CS0618)

### Unit tests
- Added comprehensive `BinaryReadStream` unit tests covering read operations, position tracking, edge cases, and error handling

### Project infrastructure
- Migrated from `.sln` to `.slnx` format
- Prevented nightly CI publish from running on forks
- NuGet package dependency cleanup